### PR TITLE
Refactor corne.keymap to include copy/paste macros

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -1,84 +1,73 @@
-/*
- * Copyright (c) 2020 The ZMK Contributors
- *
- * SPDX-License-Identifier: MIT
- */
-
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
-#include <dt-bindings/zmk/ext_power.h>
-#include <dt-bindings/led/led.h>
-#include <dt-bindings/zmk/backlight.h>
 #include <dt-bindings/zmk/rgb.h>
-#include <dt-bindings/zmk/reset.h>
-
-&led_strip {
-    chain-length = <27>;
-};
 
 / {
+    // Definición de Macros para Backend
+    macros {
+        // Macro para Copiar (Ctrl + C)
+        m_copy: m_copy {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings = <&macro_press &kp LCTRL>, <&macro_tap &kp C>, <&macro_release &kp LCTRL>;
+        };
+        // Macro para Pegar (Ctrl + V)
+        m_paste: m_paste {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings = <&macro_press &kp LCTRL>, <&macro_tap &kp V>, <&macro_release &kp LCTRL>;
+        };
+    };
+
     keymap {
         compatible = "zmk,keymap";
 
         default_layer {
             display-name = "BAS";
-            // -----------------------------------------------------------------------------------------
-            // |  TAB |  Q  |  W  |  E  |  R  |  T  |   |  Y  |  U   |  I  |  O  |  P  | BKSP |
-            // | CTRL |  A  |  S  |  D  |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  |  '   |
-            // | SHFT |  Z  |  X  |  C  |  V  |  B  |   |  N  |  M   |  ,  |  .  |  /  | ESC  |
-            //                    | GUI | LWR | SPC |   | ENT | RSE  | ALT |
-
+            // Lado Izquierdo: Shift arriba, Ctrl abajo. Caps Lock en la esquina derecha.
             bindings = <
 &kp TAB    &kp Q  &kp W  &kp E     &kp R  &kp T        &kp Y    &kp U  &kp I      &kp O    &kp P     &kp BSPC
-&kp LCTRL  &kp A  &kp S  &kp D     &kp F  &kp G        &kp H    &kp J  &kp K      &kp L    &kp SEMI  &kp SQT
-&kp LSHFT  &kp Z  &kp X  &kp C     &kp V  &kp B        &kp N    &kp M  &kp COMMA  &kp DOT  &kp FSLH  &kp ESC
+&kp LSHFT  &kp A  &kp S  &kp D     &kp F  &kp G        &kp H    &kp J  &kp K      &kp L    &kp SEMI  &kp SQT
+&kp LCTRL  &kp Z  &kp X  &kp C     &kp V  &kp B        &kp N    &kp M  &kp COMMA  &kp DOT  &kp FSLH  &kp CAPS
                          &kp LGUI  &mo 1  &kp SPACE    &kp RET  &mo 2  &kp RALT
             >;
         };
 
         lower_layer {
             display-name = "LOW";
-            // -----------------------------------------------------------------------------------------
-            // |  TAB |  1  |  2  |  3  |  4  |  5  |   |  6  |  7  |  8  |  9  |  0  | BKSP |
-            // | BTCLR| BT1 | BT2 | BT3 | BT4 | BT5 |   | LFT | DWN |  UP | RGT |     |      |
-            // | SHFT |     |     |     |     |     |   |     |     |     |     |     |      |
-            //                    | GUI |     | SPC |   | ENT |     | ALT |
-
+            // Lado Izq: Símbolos de programación ({ } [ ] ( ) < > = !). 
+            // Lado Der: Teclado numérico estilo Numlock (U=7, J=4, M=1).
             bindings = <
-&kp TAB     &kp N1        &kp N2        &kp N3        &kp N4        &kp N5          &kp N6    &kp N7    &kp N8    &kp N9     &kp N0  &kp BSPC
-&bt BT_CLR  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4    &kp LEFT  &kp DOWN  &kp UP    &kp RIGHT  &trans  &trans
-&kp LSHFT   &trans        &trans        &trans        &trans        &trans          &trans    &trans    &trans    &trans     &trans  &trans
-                                        &kp LGUI      &trans        &kp SPACE       &kp RET   &trans    &kp RALT
+&kp TAB    &kp LBRC  &kp RBRC  &kp LBKT  &kp RBKT  &kp LPAR     &kp KP_MULTIPLY  &kp N7  &kp N8  &kp N9  &kp KP_MINUS  &kp BSPC
+&kp LSHFT  &kp LT    &kp GT    &kp LPAR  &kp RPAR  &kp EQUAL    &kp KP_DIVIDE    &kp N4  &kp N5  &kp N6  &kp KP_PLUS   &trans
+&kp LCTRL  &kp EXCL  &kp AT    &kp HASH  &kp DLLR  &kp PRCNT    &kp N0           &kp N1  &kp N2  &kp N3  &kp KP_DOT    &trans
+                               &kp LGUI  &trans    &kp SPACE    &kp RET          &mo 3   &kp RALT
             >;
         };
 
         raise_layer {
             display-name = "RAI";
-            // -----------------------------------------------------------------------------------------
-            // |  TAB |  !  |  @  |  #  |  $  |  %  |   |  ^  |  &  |  *  |  (  |  )  | BKSP |
-            // | CTRL |     |     |     |     |     |   |  -  |  =  |  [  |  ]  |  \  |  `   |
-            // | SHFT |     |     |     |     |     |   |  _  |  +  |  {  |  }  | "|" |  ~   |
-            //                    | GUI |     | SPC |   | ENT |     | ALT |
-
+            // Lado Der: Control de luces RGB (Brillo, Color, Efectos).
             bindings = <
-&kp TAB    &kp EXCL  &kp AT  &kp HASH   &kp DLLR  &kp PRCNT    &kp CARET  &kp AMPS   &kp KP_MULTIPLY  &kp LPAR  &kp RPAR  &kp BSPC
-&kp LCTRL  &trans    &trans  &trans  &trans    &trans    &kp MINUS  &kp EQUAL  &kp LBKT         &kp RBKT  &kp BSLH  &kp GRAVE
-&kp LSHFT  &trans    &trans  &trans     &trans    &trans       &kp UNDER  &kp PLUS   &kp LBRC         &kp RBRC  &kp PIPE  &kp TILDE
-                             &kp LGUI   &studio_unlock    &kp SPACE    &kp RET    &studio_unlock     &kp RALT
+&kp TAB    &trans  &trans  &trans  &trans  &trans       &kp CARET  &kp AMPS  &kp KP_MULTIPLY  &kp LPAR  &kp RPAR  &kp BSPC
+&kp LSHFT  &trans  &trans  &trans  &trans  &trans       &rgb_ug RGB_TOG  &rgb_ug RGB_BRI  &rgb_ug RGB_HUI  &rgb_ug RGB_SAI  &rgb_ug RGB_EFF  &trans
+&kp LCTRL  &trans  &trans  &trans  &trans  &trans       &rgb_ug RGB_COLOR_HSB(120,100,50) &rgb_ug RGB_BRD  &rgb_ug RGB_HUD  &rgb_ug RGB_SAD  &trans  &trans
+                           &kp LGUI  &mo 3  &kp SPACE    &kp RET    &trans    &kp RALT
             >;
         };
-        extra_1 {
-            status = "reserved";
-        };
 
-        extra_2 {
-            status = "reserved";
-        };
-
-        extra_3 {
-            status = "reserved";
+        adjust_layer {
+            display-name = "ADJ";
+            // SE ACTIVA CON LWR + RAI. 
+            // Mano IZQ: Macros de Copiar (W) y Pegar (E).
+            // Mano DER: Flechas (M=Izq, ,=Abajo, .=Arriba, /=Derecha).
+            bindings = <
+&kp TAB    &trans     &m_copy    &m_paste   &trans     &trans       &trans    &trans    &trans    &trans     &trans     &kp BSPC
+&bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &trans    &trans    &kp UP    &trans     &trans     &trans
+&kp LCTRL  &trans     &trans     &trans     &trans     &trans       &trans    &kp LEFT  &kp DOWN  &kp RIGHT  &trans     &trans
+                                 &kp LGUI   &trans     &kp SPACE    &kp RET   &trans    &kp RALT
+            >;
         };
     };
 };


### PR DESCRIPTION
Removed unused includes and added macros for copy and paste functionality.